### PR TITLE
Use base URL for shadow site

### DIFF
--- a/.github/workflows/shadow.yml
+++ b/.github/workflows/shadow.yml
@@ -19,7 +19,7 @@ jobs:
           # extended: true
 
       - name: Build
-        run: hugo --minify
+        run: hugo -b https://studieverenigingstorm.github.io/BAPC21-site/ --minify
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
When visiting the shadow site on:
https://studieverenigingstorm.github.io/BAPC21-site/

the jury page link uses the wrong root, this should fix it.