### PR TITLE
Minor edits on contact and home pages

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,4 +6,4 @@ The Benelux Algorithm Programming Contest (BAPC) is a contest in which teams fro
 
 The teams that have solved the most puzzles at the end of the contest qualify for the [Northwestern European Regional Contest (NWERC)](https://www.nwerc.eu). In this regional competition the teams can qualify themselves for a ticket to the [International Collegiate Programming Contest (ICPC)](https://icpc.global), also known as the World Finals.
 
-The [Vrije Universiteit Amsterdam](https://www.vu.nl/) hosts the BAPC 2021, organized by a committee of [study association STORM](https://storm.vu).
+The BAPC 2021 is hosted by [Vrije Universiteit Amsterdam](https://www.vu.nl/), and organized by a committee of [study association STORM](https://storm.vu).

--- a/content/contact.md
+++ b/content/contact.md
@@ -10,7 +10,7 @@ If you have any questions or want to the contact the BAPC 2021 committee, please
 
 ## Sponsoring
 
-Companies interested in supporting the contest or participating as a company team, can email us at: claudia “at” STORM “dot” VU.
+Companies interested in supporting the contest or participating as a company team, can email us at: Claudia “at” STORM “dot” VU.
 
 ## Organization
 

--- a/content/contact.md
+++ b/content/contact.md
@@ -6,15 +6,11 @@ weight: 5
 
 # Contact
 
-If you have any questions or want to the contact the 2021 BAPC committee, please drop us an email at: organization “at” BAPC “dot” EU (not active yet).
+If you have any questions or want to the contact the BAPC 2021 committee, please drop us an email at: organization “at” BAPC “dot” EU (not active yet).
 
 ## Sponsoring
 
-Companies interested in supporting the contest or participating as a company team, can email us at: Claudia “at” STORM “dot” VU.
-
-## Jury
-
-The [Call for Problems](../jury) is open for both problems and jury members. For questions see the information at the [Jury site](https://jury.bapc.eu).
+Companies interested in supporting the contest or participating as a company team, can email us at: claudia “at” STORM “dot” VU.
 
 ## Organization
 


### PR DESCRIPTION
Removed outdated Jury information from the Contact page and rephrased the last sentenced on the Home page.