### PR TITLE
open third-party links in new tab

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text }}</a>


### PR DESCRIPTION
Links open in new tabs locally, but not on 2021.bapc.eu (and I'm not sure this fixes it either)