### PR TITLE
Meta generator

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,4 +2,5 @@ baseURL = "https://bapc21.storm.vu/"
 languageCode = "en-us"
 title = "BAPC21 Vrije Universiteit Amsterdam"
 theme = "BAPC21-theme"
+disableHugoGeneratorInject = true
 


### PR DESCRIPTION
Already verified locally,

The problem is that when generating a site the first tag is a meta generator tag, where this should first be the encoding. In a later commit we can add the generated by tag again to show our support to gohugo.