### PR TITLE
Add a Dockerfile and update BAPC21-theme submodule

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.github
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+
+
+FROM alpine:latest
+
+ARG HUGO_VERSION=0.68.3
+
+RUN apk add git
+
+WORKDIR /tmp
+RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -O hugo.tar.gz \
+	&& tar -xzf hugo.tar.gz \
+	&& cp hugo /opt/hugo \
+	&& rm -rf /tmp/*
+
+WORKDIR /usr/src/app
+COPY . .
+RUN git submodule init && git submodule update --remote --merge
+
+EXPOSE 1313
+CMD [ "/opt/hugo", "server", "--bind=0.0.0.0" ]
+


### PR DESCRIPTION
Containerizing the site so we can deploy it elsewhere.

I ran into some compatibility issues while trying to generate using the latest Hugo version. The Dockerfile uses the binary for Hugo 0.68.3 found here: https://github.com/gohugoio/hugo/releases

```bash
docker build -t bapc21-site .
docker run -p 1313 bapc21-site
```